### PR TITLE
Small Fix on Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,17 +36,10 @@ Clone plugin into local workspace
 git clone https://github.com/Raybeam/rb_status_plugin plugins/rb_status_plugin
 ```
 Run plugin's deploy script.  
-
-### macOS
-```
-. plugins/rb_status_plugin/deploy.sh
-```
-
-### Ubuntu
 ```
 ./plugins/rb_status_plugin/deploy.sh
 ```
-
+  
 ## Set up : Local Deploy
 
 ### Set up the Python virtual environment


### PR DESCRIPTION
Removing separate workflows in readme for mac and linux users..

On both OSs it's better use a new shell process for running script, so the script can exit without closing the terminal. 

